### PR TITLE
added version attribute to allow for newer ps builds

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,6 @@ if node['platform_family'] == 'windows'
 
   # For enabling HTTPS transport in winrm recipe
   default['powershell']['winrm']['enable_https_transport'] = false
-  default['powershell']['winrm']['thumbprint'] = ''		# mandatory for https transport
+  default['powershell']['winrm']['thumbprint'] = '' # mandatory for https transport
   default['powershell']['winrm']['hostname'] = ''
 end

--- a/attributes/powershell5.rb
+++ b/attributes/powershell5.rb
@@ -23,9 +23,11 @@ if node['platform_family'] == 'windows'
   when '6.3'
     case node['kernel']['machine']
     when 'i386'
+      default['powershell']['powershell5']['version'] = '5.0.9701.0'
       default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/B/5/1/B5130F9A-6F07-481A-B4A6-CEDED7C96AE2/WindowsBlue-KB3037315-x86.msu'
       default['powershell']['powershell5']['checksum'] = '7929cfb10fa07f5f9ce5a24e44977d63054b27a3fa51db10242193269120305f'
     when 'x86_64'
+      default['powershell']['powershell5']['version'] = '5.0.9701.0'
       default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/B/5/1/B5130F9A-6F07-481A-B4A6-CEDED7C96AE2/WindowsBlue-KB3037315-x64.msu'
       default['powershell']['powershell5']['checksum'] = '9a24de7b85fae96a87188a7fdaab27da3bc90d89426594cdc5f962234a61b7bd'
     end

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -43,7 +43,7 @@ when 'windows'
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
-      not_if { registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', { :name => 'PowerShellVersion', :type => :string, :data => '5.0.9701.0' }) }
+      not_if { registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', { :name => 'PowerShellVersion', :type => :string, :data => node['powershell']['powershell5']['version'] }) }
     end
 
   else


### PR DESCRIPTION
This should just make upgrading to later powershell builds easier. 
This change will allow users to easily override the default powershell version in the cookbook by just changing the attributes.