### PR TITLE
Correct PS5 versionnumber

### DIFF
--- a/attributes/powershell5.rb
+++ b/attributes/powershell5.rb
@@ -23,11 +23,11 @@ if node['platform_family'] == 'windows'
   when '6.3'
     case node['kernel']['machine']
     when 'i386'
-      default['powershell']['powershell5']['version'] = '5.0.9701.0'
+      default['powershell']['powershell5']['version'] = '5.0.10018.0'
       default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/B/5/1/B5130F9A-6F07-481A-B4A6-CEDED7C96AE2/WindowsBlue-KB3037315-x86.msu'
       default['powershell']['powershell5']['checksum'] = '7929cfb10fa07f5f9ce5a24e44977d63054b27a3fa51db10242193269120305f'
     when 'x86_64'
-      default['powershell']['powershell5']['version'] = '5.0.9701.0'
+      default['powershell']['powershell5']['version'] = '5.0.10018.0'
       default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/B/5/1/B5130F9A-6F07-481A-B4A6-CEDED7C96AE2/WindowsBlue-KB3037315-x64.msu'
       default['powershell']['powershell5']['checksum'] = '9a24de7b85fae96a87188a7fdaab27da3bc90d89426594cdc5f962234a61b7bd'
     end


### PR DESCRIPTION
Probably solves some of the problems mentioned in #48 and #40 (at least for PowerShell 5).

With #42 PowerShell 5 was updated with the Feb release, but the version check was not updated.

At the very least this causes the resource/install to happen each time.
Unfortunately the installer has some weird behavior where the return code (after retries at installation) will eventually end up at `2359302`. It can also be considered to add this code as an acceptable return code.