### PR TITLE
Provide powershell_version helper

### DIFF
--- a/libraries/powershell_version.rb
+++ b/libraries/powershell_version.rb
@@ -1,0 +1,39 @@
+require 'chef/dsl/registry_helper'
+
+module Powershell
+  class PowershellVersionHelper
+    include Chef::DSL::RegistryHelper
+
+    def run_context
+      Chef.run_context
+    end
+
+    def powershell_version?(versionstring)
+      Gem::Version.new(powershell_version) >= Gem::Version.new(versionstring)
+    end
+
+    def powershell_version
+      reg_keys = [{ key: 'HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', value: 'PowerShellVersion' },
+                  { key: 'HKLM\SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', value: 'PowerShellVersion' }]
+      reg_keys.each do |x|
+        return registry_get_values(x[:key]).find { |i| i[:name] == x[:value] }[:data] if
+          registry_key_exists?(x[:key]) &&
+          registry_value_exists?(x[:key], name: x[:value], type: :string)
+      end
+      nil
+    end
+  end
+
+  module VersionHelper
+    def powershell_version
+      Powershell::PowershellVersionHelper.new.powershell_version
+    end
+
+    def powershell_version?(versionstring = nil)
+      Powershell::PowershellVersionHelper.new.powershell_version?(versionstring)
+    end
+  end
+end
+
+Chef::Recipe.send(:include, Powershell::VersionHelper)
+Chef::Resource.send(:include, Powershell::VersionHelper)

--- a/recipes/powershell2.rb
+++ b/recipes/powershell2.rb
@@ -56,13 +56,7 @@ when 'windows'
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
-      not_if do
-        begin
-          registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine', name: 'PowerShellVersion', type: :string, data: '2.0')
-        rescue Chef::Exceptions::Win32RegKeyMissing
-          false
-        end
-      end
+      not_if { powershell_version?('2.0') }
     end
   else
     Chef::Log.warn("PowerShell 2.0 is not supported or already installed on this version of Windows: #{node['platform_version']}")

--- a/recipes/powershell3.rb
+++ b/recipes/powershell3.rb
@@ -60,14 +60,7 @@ when 'windows'
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
-      not_if do
-        begin
-          registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', name: 'PowerShellVersion', type: :string, data: '3.0')
-        rescue Chef::Exceptions::Win32RegKeyMissing
-          # whole tree is missing if Powershell 3 not installed; that's okay
-          false
-        end
-      end
+      not_if { powershell_version?('3.0') }
     end
   else
     Chef::Log.warn("PowerShell 3.0 is not supported or already installed on this version of Windows: #{node['platform_version']}")

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -46,13 +46,7 @@ if node['platform'] == 'windows'
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
-      not_if do
-        begin
-          registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', name: 'PowerShellVersion', type: :string, data: '4.0')
-        rescue Chef::Exceptions::Win32RegKeyMissing
-          false
-        end
-      end
+      not_if { powershell_version?('4.0') }
     end
   else
     Chef::Log.warn("PowerShell 4.0 is not supported or already installed on this version of Windows: #{node['platform_version']}")

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -39,7 +39,7 @@ when 'windows'
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
-      not_if { registry_data_exists?('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', name: 'PowerShellVersion', type: :string, data: node['powershell']['powershell5']['version']) }
+      not_if { powershell_version?(node['powershell']['powershell5']['version']) }
     end
 
   else

--- a/spec/libraries/powershell_version_spec.rb
+++ b/spec/libraries/powershell_version_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+include Powershell
+include Powershell::VersionHelper
+
+shared_examples 'version retrieval' do |version, lower_semver_version, higher_version, higher_semver_version|
+  it 'retrieves the Powershell version via helper' do
+    expect(powershell_version).to eq(version)
+  end
+  it 'returns true if queried with same version' do
+    expect(powershell_version?(version)).to be true
+  end
+  it 'returns true if queried with lower (SemVer) version' do
+    expect(powershell_version?(lower_semver_version)).to be true
+  end
+  it 'returns false if queried with higher version' do
+    expect(powershell_version?(higher_version)).not_to be true
+  end
+  it 'returns false if queried with higher (SemVer) version' do
+    expect(powershell_version?(higher_semver_version)).not_to be true
+  end
+end
+
+describe PowershellVersionHelper do
+  context 'without Powershell' do
+    before do
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_key_exists?).and_return(false)
+    end
+
+    it 'retrieves the Powershell version via helper' do
+      powershell_version.nil? == true
+    end
+
+    it 'returns false if queried with any version' do
+      powershell_version?('0.0') == false
+    end
+  end
+
+  versionV1 = '1.0.101'
+  versionV3 = '3.0.101'
+  context 'with Powershell v1/v2' do
+    before do
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_value_exists?).and_return(true)
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine').and_return(true)
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine').and_return(false)
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_get_values).with('HKLM\SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine').and_return([{ name: 'PowerShellVersion', type: :string, data: versionV1 }])
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_get_values).with('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine').and_return([{ name: 'PowerShellVersion', type: :string, data: versionV3 }])
+    end
+    include_examples 'version retrieval', '1.0.101', '1.0.99', '1.0.102', '1.0.1000'
+  end
+  context 'with Powershell v3+' do
+    before do
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_value_exists?).and_return(true)
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine').and_return(true)
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_key_exists?).with('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine').and_return(true)
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_get_values).with('HKLM\SOFTWARE\Microsoft\PowerShell\1\PowerShellEngine').and_return([{ name: 'PowerShellVersion', type: :string, data: versionV1 }])
+      allow_any_instance_of(Powershell::PowershellVersionHelper).to receive(:registry_get_values).with('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine').and_return([{ name: 'PowerShellVersion', type: :string, data: versionV3 }])
+    end
+    include_examples 'version retrieval', '3.0.101', '3.0.99', '3.0.102', '3.0.1000'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,6 @@ require 'helpers/matchers'
 def not_windows?
   (RUBY_PLATFORM =~ /mswin|mingw|windows/).nil?
 end
+
+# Require all our libraries
+Dir['libraries/*.rb'].each { |f| require File.expand_path(f) }


### PR DESCRIPTION
Written a helper function which returns (true/false) if the requested versionlevel is present.

This simplifies the guards, and provides a method for other cookbooks to check if a minimum version is present. E.g.  WMF5/Feb versionlevel is required for certain DSC (Chef 12) stuff, while with Chef 11 the WMF5-2014 is already enough.

~~Perhaps~~ not the most beautiful code (let me know how/where to adjust/improve), but useful nonetheless :wink: