### PR TITLE
Use all-in-one ms_dotnet cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ Not every version of Windows supports every version of Powershell. The following
 
 PowerShell also requires the appropriate version of the Microsoft .NET Framework to be installed, if the operating system does not ship with that version. The following community cookbooks are used to install the correct version of the .NET Framework:
 
-* ms_dotnet2
-* ms_dotnet4
-* ms_dotnet45
+* ms_dotnet
 
 Resource/Provider
 -----------------

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,9 +16,7 @@ recipe 'powershell::dsc', 'Desired State Configuration'
 
 supports 'windows'
 depends 'windows', '>= 1.2.8'
-depends 'ms_dotnet45'
-depends 'ms_dotnet4'
-depends 'ms_dotnet2'
+depends 'ms_dotnet', '>= 2.6'
 depends 'chef_handler'
 
 source_url 'https://github.com/chef-cookbooks/powershell' if respond_to?(:source_url)

--- a/recipes/powershell2.rb
+++ b/recipes/powershell2.rb
@@ -46,7 +46,7 @@ when 'windows'
     # Reboot if user specifies doesn't specify no_reboot
     include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
 
-    windows_package 'Windows Management Framework Core' do
+    windows_package 'Windows Management Framework Core' do # ~FC009
       source node['powershell']['powershell2']['url']
       checksum node['powershell']['powershell2']['checksum']
       installer_type :custom

--- a/recipes/powershell2.rb
+++ b/recipes/powershell2.rb
@@ -23,44 +23,26 @@
 
 case node['platform']
 when 'windows'
+  nt_version = ::Windows::VersionHelper.nt_version(node)
 
-  require 'chef/win32/version'
-  windows_version = Chef::ReservedNames::Win32::Version.new
+  include_recipe 'ms_dotnet::ms_dotnet2'
 
-  if (windows_version.windows_server_2012? || windows_version.windows_8?) && windows_version.core?
-    # Windows Server 2012 Core does not come with Powershell 2.0 enabled
+  if nt_version.between?(6.1, 6.2) && ::Windows::VersionHelper.core_version?(node)
+    feature_suffix = 'V2' if nt_version == 6.2
 
-    windows_feature 'MicrosoftWindowsPowerShellV2' do
+    windows_feature "MicrosoftWindowsPowerShell#{feature_suffix}" do
       action :install
     end
-    windows_feature 'MicrosoftWindowsPowerShellV2-WOW64' do
-      action :install
-      only_if { node['kernel']['machine'] == 'x86_64' }
-    end
 
-  elsif (windows_version.windows_server_2008_r2? || windows_version.windows_7?) && windows_version.core?
-    # Windows Server 2008 R2 Core does not come with .NET or Powershell 2.0 enabled
-
-    windows_feature 'NetFx2-ServerCore' do
-      action :install
-    end
-    windows_feature 'NetFx2-ServerCore-WOW64' do
-      action :install
-      only_if { node['kernel']['machine'] == 'x86_64' }
-    end
-    windows_feature 'MicrosoftWindowsPowerShell' do
-      action :install
-    end
-    windows_feature 'MicrosoftWindowsPowerShell-WOW64' do
+    windows_feature "MicrosoftWindowsPowerShell#{feature_suffix}-WOW64" do
       action :install
       only_if { node['kernel']['machine'] == 'x86_64' }
     end
 
-  elsif windows_version.windows_server_2008? || windows_version.windows_server_2003_r2? ||
-        windows_version.windows_server_2003? || windows_version.windows_xp?
-
-    include_recipe 'ms_dotnet2'
-
+  # WMF 2.0 is required and only compatible with:
+  # * Windows NT 5.1 & 5.2 (Windows Server 2003 & Windows XP)
+  # * Windows NT 6.0 server (Windows Server 2008 SP2 not vista)
+  elsif nt_version.between?(5.1, 5.2) || (nt_version == 6.0 && ::Windows::VersionHelper.server_version?(node))
     # Reboot if user specifies doesn't specify no_reboot
     include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
 

--- a/recipes/powershell3.rb
+++ b/recipes/powershell3.rb
@@ -50,7 +50,7 @@ when 'windows'
     # Reboot if user specifies doesn't specify no_reboot
     include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
 
-    windows_package 'Windows Management Framework Core 3.0' do
+    windows_package 'Windows Management Framework Core 3.0' do # ~FC009
       source node['powershell']['powershell3']['url']
       checksum node['powershell']['powershell3']['checksum']
       installer_type :custom

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -36,7 +36,7 @@ if node['platform'] == 'windows'
     # Reboot if user specifies doesn't specify no_reboot
     include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
 
-    windows_package 'Windows Management Framework Core4.0' do
+    windows_package 'Windows Management Framework Core 4.0' do # ~FC009
       source node['powershell']['powershell4']['url']
       checksum node['powershell']['powershell4']['checksum']
       installer_type :custom

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -22,13 +22,16 @@
 # http://www.microsoft.com/en-us/download/details.aspx?id=40855
 
 if node['platform'] == 'windows'
-  require 'chef/win32/version'
-  windows_version = Chef::ReservedNames::Win32::Version.new
 
-  if windows_version.windows_server_2008_r2? || windows_version.windows_7? || windows_version.windows_server_2012?
+  nt_version = ::Windows::VersionHelper.nt_version(node)
+  # WMF 4.0 is only compatible with:
+  # * Windows NT 6.1 (Windows Server 2008R2 & Windows 7.1)
+  # * Windows NT 6.2 Server (Windows Server 2012 not Windows 8)
+  if nt_version == 6.1 || (nt_version == 6.2 && ::Windows::VersionHelper.server_version?(node))
 
-    # Ensure .NET 4.5 is installed or installation will fail silently per Microsoft. Only necessary for Windows 2008R2 or 7.
-    include_recipe 'ms_dotnet45' if windows_version.windows_server_2008_r2? || windows_version.windows_7?
+    # Ensure .NET 4.5 is installed or installation will fail silently per Microsoft.
+    fail 'Attribute ms_dotnet.v4.version is not configured to install .NET4.5 as required for Powershell4' if node['ms_dotnet']['v4']['version'] < '4.5'
+    include_recipe 'ms_dotnet::ms_dotnet4'
 
     # Reboot if user specifies doesn't specify no_reboot
     include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -30,7 +30,7 @@ when 'windows'
 
     include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
 
-    windows_package 'Windows Management Framework Core 5.0' do
+    windows_package 'Windows Management Framework Core 5.0' do # ~FC009
       source node['powershell']['powershell5']['url']
       checksum node['powershell']['powershell5']['checksum']
       installer_type :custom

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -21,15 +21,12 @@
 # PowerShell 5.0 Preview Download Page
 # http://www.microsoft.com/en-us/download/details.aspx?id=42316
 
-include_recipe 'powershell::powershell2'
-
 case node['platform']
 when 'windows'
 
-  require 'chef/win32/version'
-  windows_version = Chef::ReservedNames::Win32::Version.new
-
-  if windows_version.windows_server_2012_r2? || windows_version.windows_8_1?
+  # Handle WMFC install on 2012R2 and 8.1 only (yet)
+  if ::Windows::VersionHelper.nt_version(node) == 6.3
+    include_recipe 'powershell::powershell2'
 
     include_recipe 'powershell::windows_reboot' unless node['powershell']['installation_reboot_mode'] == 'no_reboot'
 

--- a/recipes/winrm.rb
+++ b/recipes/winrm.rb
@@ -34,15 +34,13 @@ when 'windows'
   shell_out = Mixlib::ShellOut.new(winrm_cmd)
   shell_out.run_command
 
-  if !shell_out.stdout.include? 'Transport = HTTPS'
-    # Create HTTPS listener
-    if node['powershell']['winrm']['enable_https_transport']
-      if node['powershell']['winrm']['thumbprint'].empty? || node['powershell']['winrm']['thumbprint'].nil?
-        Chef::Log.error('Please specify thumbprint in default attributes for enabling https transport.')
-      else
-        powershell_script 'winrm-create-https-listener' do
-          code "winrm create 'winrm/config/Listener?Address=*+Transport=HTTPS' '@{Hostname=\"#{node['powershell']['winrm']['hostname']}\"; CertificateThumbprint=\"#{node['powershell']['winrm']['thumbprint']}\"}'"
-        end
+  # Create HTTPS listener
+  if !shell_out.stdout.include?('Transport = HTTPS') && node['powershell']['winrm']['enable_https_transport']
+    if node['powershell']['winrm']['thumbprint'].nil? || node['powershell']['winrm']['thumbprint'].empty?
+      Chef::Log.error('Please specify thumbprint in default attributes for enabling https transport.')
+    else
+      powershell_script 'winrm-create-https-listener' do
+        code "winrm create 'winrm/config/Listener?Address=*+Transport=HTTPS' '@{Hostname=\"#{node['powershell']['winrm']['hostname']}\"; CertificateThumbprint=\"#{node['powershell']['winrm']['thumbprint']}\"}'"
       end
     end
   else

--- a/spec/recipes/powershell2_spec.rb
+++ b/spec/recipes/powershell2_spec.rb
@@ -1,18 +1,11 @@
 require 'spec_helper'
-require 'chef/win32/version'
 
 describe 'powershell::powershell2' do
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
-      node.set['powershell']['powershell2']['url'] = 'https://powershelltest.com'
-      node.set['powershell']['powershell2']['checksum'] = '12345'
-    end.converge(described_recipe)
-  end
-
-  context 'when windows_version is windows_server_2012 and windows_version is core ' do
-    before do
-      @windows_version = double(windows_server_2012?: true, windows_8?: false, core?: true)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
+  context 'on Windows Server 2012 Core' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
+        node.automatic['kernel']['os_info']['operating_system_sku'] = 0x0D
+      end.converge(described_recipe)
     end
 
     it 'installs windows features' do
@@ -21,25 +14,14 @@ describe 'powershell::powershell2' do
     end
   end
 
-  context 'when windows_version is windows_8 and windows_version is core ' do
-    before do
-      @windows_version = double(windows_server_2012?: false, windows_8?: true, core?: true)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
+  context 'on Windows Server 2008R2 Core' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2') do |node|
+        node.automatic['kernel']['os_info']['operating_system_sku'] = 0x0D
+      end.converge(described_recipe)
     end
 
     it 'installs windows features' do
-      expect(chef_run).to install_windows_feature('MicrosoftWindowsPowerShellV2')
-      expect(chef_run).to install_windows_feature('MicrosoftWindowsPowerShellV2-WOW64')
-    end
-  end
-
-  context 'when windows_version is windows_server_2008_r2 and windows_version is core ' do
-    before do
-      @windows_version = double(windows_server_2008_r2?: true, windows_7?: false, core?: true, windows_server_2012?: false, windows_8?: false)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-    end
-
-    it 'installs windows feature' do
       expect(chef_run).to install_windows_feature('NetFx2-ServerCore')
       expect(chef_run).to install_windows_feature('NetFx2-ServerCore-WOW64')
       expect(chef_run).to install_windows_feature('MicrosoftWindowsPowerShell')
@@ -47,46 +29,36 @@ describe 'powershell::powershell2' do
     end
   end
 
-  context 'when windows_version is windows_7 and windows_version is core' do
-    before do
-      @windows_version = double(windows_server_2008_r2?: false, windows_7?: true, core?: true, windows_server_2012?: false, windows_8?: false)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
+  context 'on Windows Server 2008' do
+    let(:chef_run) do
+      # There is no fauxhai info for windows server 2008, so we use 2008R2 and change the platform version
+      ChefSpec::SoloRunner.new(platform: 'windows', version: '2008R2') do |node|
+        node.automatic['platform_version'] = '6.0.6001'
+        node.set['powershell']['powershell2']['url'] = 'https://powershelltest.com'
+        node.set['powershell']['powershell2']['checksum'] = '12345'
+      end.converge(described_recipe)
     end
 
-    it 'installs windows feature' do
-      expect(chef_run).to install_windows_feature('NetFx2-ServerCore')
-      expect(chef_run).to install_windows_feature('NetFx2-ServerCore-WOW64')
-      expect(chef_run).to install_windows_feature('MicrosoftWindowsPowerShell')
-      expect(chef_run).to install_windows_feature('MicrosoftWindowsPowerShell-WOW64')
-    end
-  end
+    context 'when powershell2 does not exist' do
+      before do
+        allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: false, value_exists?: false, key_exists?: false)
+      end
 
-  context 'when windows_version is windows_server_2008' do
-    before do
-      @windows_version = double(windows_server_2008?: true, windows_server_2003_r2?: false, windows_server_2003?: false, windows_xp?: false, windows_server_2008_r2?: false, windows_7?: false, core?: false, windows_server_2012?: false, windows_8?: false)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(false)
+      it 'installs windows package' do
+        expect(chef_run).to include_recipe('ms_dotnet::ms_dotnet2')
+        expect(chef_run).to install_windows_package('Windows Management Framework Core').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
+      end
     end
 
-    it 'installs windows package when powershell2 doesnot exist' do
-      expect(chef_run).to include_recipe('ms_dotnet2')
-      expect(chef_run).to install_windows_package('Windows Management Framework Core').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
-    end
-  end
+    context 'when powershell2 exist' do
+      before do
+        allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: true, value_exists?: true)
+      end
 
-  context 'when windows_version is windows_server_2008' do
-    before do
-      @windows_version = double(windows_server_2008?: true, windows_server_2003_r2?: false, windows_server_2003?: false, windows_xp?: false, windows_server_2008_r2?: false, windows_7?: false, core?: false, windows_server_2012?: false, windows_8?: false)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(true)
-    end
-
-    it 'only includes ms_dotnet2 when powershell2 exist' do
-      expect(chef_run).to include_recipe('ms_dotnet2')
+      it 'only includes ms_dotnet2' do
+        expect(chef_run).to include_recipe('ms_dotnet::ms_dotnet2')
+        expect(chef_run).to_not install_windows_package('Windows Management Framework Core')
+      end
     end
   end
 end

--- a/spec/recipes/powershell3_spec.rb
+++ b/spec/recipes/powershell3_spec.rb
@@ -1,87 +1,58 @@
 require 'spec_helper'
-require 'chef/win32/version'
 
 describe 'powershell::powershell3' do
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
-      node.set['powershell']['powershell3']['url'] = 'https://powershelltest.com'
-      node.set['powershell']['powershell3']['checksum'] = '12345'
-      node.set['powershell']['bits_4']['url'] = 'https://powershellbits.com'
-      node.set['powershell']['bits_4']['checksum'] = '99999'
-    end.converge(described_recipe)
-  end
+  {
+    'Windows Server 2008R2' => { fauxhai_version: '2008R2', should_install_bits: false },
+    # There is no fauxhai info for windows server 2008, so we use 2008R2 and change the platform version
+    'Windows Server 2008' => { fauxhai_version: '2008R2', platform_version: '6.0.6001', should_install_bits: true },
+    # There is no fauxhai info for windows 7, so we use 2008R2 and change the product type from server to workstation
+    'Windows 7' => { fauxhai_version: '2008R2', product_type: 1, should_install_bits: false }
+  }.each do |windows_version, test_conf|
+    context "on #{windows_version}" do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'windows', version: test_conf[:fauxhai_version]) do |node|
+          node.automatic['platform_version'] = test_conf[:platform_version] if test_conf[:platform_version]
+          node.automatic['kernel']['os_info']['product_type'] = test_conf[:product_type] if test_conf[:product_type]
+          node.set['powershell']['powershell3']['url'] = 'https://powershelltest.com'
+          node.set['powershell']['powershell3']['checksum'] = '12345'
+          node.set['powershell']['bits_4']['url'] = 'https://powershellbits.com'
+          node.set['powershell']['bits_4']['checksum'] = '99999'
+        end.converge(described_recipe)
+      end
 
-  context 'when windows_version is windows_server_2008' do
-    before do
-      @windows_version = double(windows_server_2008?: true, windows_server_2008_r2?: false, windows_7?: false)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(false)
-      allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_return(true)
-    end
+      if test_conf[:should_install_bits]
+        it 'installs windows package Windows Management Framework Bits' do
+          allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: true, value_exists?: true)
+          expect(chef_run).to install_windows_package('Windows Management Framework Bits').with(source: 'https://powershellbits.com', checksum: '99999', installer_type: :custom, options: '/quiet /norestart')
+        end
+      else
+        it 'does not install windows package Windows Management Framework Bits' do
+          allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: true, value_exists?: true)
+          expect(chef_run).to_not install_windows_package('Windows Management Framework Bits')
+        end
+      end
 
-    it 'installs windows package windows managemet framework bits and windows management framework core 3.0' do
-      expect(chef_run).to install_windows_package('Windows Management Framework Bits').with(source: 'https://powershellbits.com', checksum: '99999', installer_type: :custom, options: '/quiet /norestart')
-      expect(chef_run).to install_windows_package('Windows Management Framework Core 3.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
-    end
-  end
+      context 'when powershell 3 is installed' do
+        before do
+          allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: true, value_exists?: true)
+        end
 
-  context 'when windows_version is windows_server_2008_r2' do
-    before do
-      @windows_version = double(windows_server_2008?: false, windows_server_2008_r2?: true, windows_7?: false)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(true)
-    end
+        it 'only include ms_dotnet4' do
+          expect(chef_run).to include_recipe('ms_dotnet::ms_dotnet4')
+          expect(chef_run).to_not install_windows_package('Windows Management Framework Core 3.0')
+        end
+      end
 
-    it 'only include ms_dotnet4 when powershell 3 is installed' do
-      expect(chef_run).to include_recipe('ms_dotnet4')
-    end
-  end
+      context 'when powershell 3 does not exist' do
+        before do
+          allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: false, value_exists?: false, key_exists?: false)
+        end
 
-  context 'when windows_version is windows_server_2008_r2' do
-    before do
-      @windows_version = double(windows_server_2008?: false, windows_server_2008_r2?: true, windows_7?: false)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(false)
-    end
-
-    it 'installs windows package windows management framework core 3.0 when powershell 3 doesnot exist' do
-      expect(chef_run).to include_recipe('ms_dotnet4')
-      expect(chef_run).to install_windows_package('Windows Management Framework Core 3.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
-    end
-  end
-
-  context 'when windows_version is windows_7' do
-    before do
-      @windows_version = double(windows_server_2008?: false, windows_server_2008_r2?: false, windows_7?: true)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(true)
-    end
-
-    it 'only include ms_dotnet4 when powershell 3 is installed' do
-      expect(chef_run).to include_recipe('ms_dotnet4')
-    end
-  end
-
-  context 'when windows_version is windows_7' do
-    before do
-      @windows_version = double(windows_server_2008?: false, windows_server_2008_r2?: false, windows_7?: true)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(false)
-    end
-
-    it 'installs windows package windows management framework core 3.0 when powershell 3 doesnot exist' do
-      expect(chef_run).to include_recipe('ms_dotnet4')
-      expect(chef_run).to install_windows_package('Windows Management Framework Core 3.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
+        it 'installs windows package windows management framework core 3.0' do
+          expect(chef_run).to include_recipe('ms_dotnet::ms_dotnet4')
+          expect(chef_run).to install_windows_package('Windows Management Framework Core 3.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
+        end
+      end
     end
   end
 end

--- a/spec/recipes/powershell4_spec.rb
+++ b/spec/recipes/powershell4_spec.rb
@@ -1,249 +1,59 @@
 require 'spec_helper'
-require 'chef/win32/version'
 
 describe 'powershell::powershell4' do
-  context 'when installation_reboot_mode is no_reboot' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
-        node.set['powershell']['powershell4']['url'] = 'https://powershelltest.com'
-        node.set['powershell']['powershell4']['checksum'] = '12345'
-        node.set['powershell']['installation_reboot_mode'] = 'no_reboot'
-      end.converge(described_recipe)
-    end
-
-    context 'when windows_version is windows_server_2008_r2' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: true, windows_7?: false, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(true)
+  {
+    # There is no fauxhai info for windows 7, so we use windows 2008R2 and change the product type from server to workstation
+    'Windows 7' => { fauxhai_version: '2008R2', product_type: 1 },
+    'Windows Server 2008R2' => { fauxhai_version: '2008R2' },
+    'Windows Server 2012' => { fauxhai_version: '2012' }
+  }.each do |windows_version, test_conf|
+    context "on #{windows_version}" do
+      let(:normal_attributes) { ::Chef::Node::VividMash.new(double('fake_node').as_null_object) }
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'windows', version: test_conf[:fauxhai_version]) do |node|
+          node.automatic['kernel']['os_info']['product_type'] = test_conf[:product_type] if test_conf[:product_type]
+          normal_attributes.each { |k, v| node.set[k] = v }
+        end.converge(described_recipe)
       end
 
-      it 'only includes ms_dotnet45 when powershell 4 is installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-      end
-    end
-
-    context 'when windows_version is windows_server_2008_r2' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: true, windows_7?: false, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
+      context 'when ms_dotnet::ms_dotnet4 is not configured for .NET 4.5' do
+        before { normal_attributes['ms_dotnet']['v4']['version'] = '4.0' }
+        it 'fails' do
+          expect { chef_run }.to raise_error
+        end
       end
 
-      it 'installs windows package windows managemet framework core 4.0 when powershell 4 is not installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
-      end
-    end
+      context 'when ms_dotnet::ms_dotnet4 is configured for .NET 4.5' do
+        before { normal_attributes['ms_dotnet']['v4']['version'] = '4.5' }
 
-    context 'when windows_version is windows_7' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: true, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(true)
-      end
+        context 'when powershell 4 is installed' do
+          before do
+            allow_any_instance_of(::Chef::Resource).to receive(:reboot_pending?).and_return false
+            expect_any_instance_of(::Chef::Resource).to receive(:registry_data_exists?).with('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', name: 'PowerShellVersion', type: :string, data: '4.0').and_return true
+          end
+          it 'includes ms_dotnet::ms_dotnet4' do
+            expect(chef_run).to include_recipe('ms_dotnet::ms_dotnet4')
+          end
+          it 'does not install windows package WMFC 4.0' do
+            expect(chef_run).to_not install_windows_package('Windows Management Framework Core 4.0')
+          end
+        end
 
-      it 'only includes ms_dotnet45 when powershell 4 is installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-      end
-    end
-
-    context 'when windows_version is windows_7' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: true, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
-      end
-
-      it 'installs windows package windows managemet framework core 4.0 when powershell 4 is not installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
-      end
-    end
-
-    context 'when windows_version is windows_server_2012' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: false, windows_server_2012?: true)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
-      end
-
-      it 'installs windows package windows managemet framework core 4.0' do
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
-      end
-    end
-  end
-
-  context 'when installation_reboot_mode is delayed_reboot' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
-        node.set['powershell']['powershell4']['url'] = 'https://powershelltest.com'
-        node.set['powershell']['powershell4']['checksum'] = '12345'
-        node.set['powershell']['installation_reboot_mode'] = 'delayed_reboot'
-      end.converge(described_recipe)
-    end
-
-    context 'when windows_version is windows_server_2008_r2' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: true, windows_7?: false, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(true)
-      end
-
-      it 'only includes ms_dotnet45 when powershell 4 is installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-      end
-    end
-
-    context 'when windows_version is windows_server_2008_r2' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: true, windows_7?: false, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
-      end
-
-      it 'installs windows package windows managemet framework core 4.0 when powershell 4 is not installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
-      end
-    end
-
-    context 'when windows_version is windows_7' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: true, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(true)
-      end
-
-      it 'only includes ms_dotnet45 when powershell 4 is installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-      end
-    end
-
-    context 'when windows_version is windows_7' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: true, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
-      end
-
-      it 'installs windows package windows managemet framework core 4.0 when powershell 4 is not installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
-      end
-    end
-
-    context 'when windows_version is windows_server_2012' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: false, windows_server_2012?: true)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
-      end
-
-      it 'installs windows package windows managemet framework core 4.0' do
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
-      end
-    end
-  end
-
-  context 'when installation_reboot_mode is immediate_reboot' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
-        node.set['powershell']['powershell4']['url'] = 'https://powershelltest.com'
-        node.set['powershell']['powershell4']['checksum'] = '12345'
-        node.set['powershell']['installation_reboot_mode'] = 'immediate_reboot'
-      end.converge(described_recipe)
-    end
-
-    context 'when windows_version is windows_server_2008_r2' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: true, windows_7?: false, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(true)
-      end
-
-      it 'only includes ms_dotnet45 when powershell 4 is installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-      end
-    end
-
-    context 'when windows_version is windows_server_2008_r2' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: true, windows_7?: false, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
-      end
-
-      it 'installs windows package windows managemet framework core 4.0 when powershell 4 is not installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
-      end
-    end
-
-    context 'when windows_version is windows_7' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: true, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(true)
-      end
-
-      it 'only includes ms_dotnet45 when powershell 4 is installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-      end
-    end
-
-    context 'when windows_version is windows_7' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: true, windows_server_2012?: false)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
-      end
-
-      it 'installs windows package windows managemet framework core 4.0 when powershell 4 is not installed' do
-        expect(chef_run).to include_recipe('ms_dotnet45')
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
-      end
-    end
-
-    context 'when windows_version is windows_server_2012' do
-      before do
-        @windows_version = double(windows_server_2008_r2?: false, windows_7?: false, windows_server_2012?: true)
-        allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-        registry = double
-        allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-        allow(registry).to receive(:data_exists?).and_return(false)
-      end
-
-      it 'installs windows package windows managemet framework core 4.0' do
-        expect(chef_run).to install_windows_package('Windows Management Framework Core4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
+        context 'when powershell 4 does not exist' do
+          before do
+            normal_attributes['powershell']['powershell4']['url'] = 'https://powershelltest.com'
+            normal_attributes['powershell']['powershell4']['checksum'] = '12345'
+            normal_attributes['powershell']['installation_reboot_mode'] = 'no_reboot'
+            allow_any_instance_of(::Chef::Resource).to receive(:reboot_pending?).and_return false
+            allow_any_instance_of(::Chef::Resource).to receive(:registry_data_exists?).with('HKLM\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine', name: 'PowerShellVersion', type: :string, data: '4.0').and_return false
+          end
+          it 'includes ms_dotnet::ms_dotnet4' do
+            expect(chef_run).to include_recipe('ms_dotnet::ms_dotnet4')
+          end
+          it 'installs windows package WMFC 4.0' do
+            expect(chef_run).to install_windows_package('Windows Management Framework Core 4.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom)
+          end
+        end
       end
     end
   end

--- a/spec/recipes/powershell5_spec.rb
+++ b/spec/recipes/powershell5_spec.rb
@@ -1,43 +1,44 @@
 require 'spec_helper'
-require 'chef/win32/version'
 
 describe 'powershell::powershell5' do
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'windows', version: '2012') do |node|
-      node.set['powershell']['powershell5']['url'] = 'https://powershelltest.com'
-      node.set['powershell']['powershell5']['checksum'] = '12345'
-    end.converge(described_recipe)
-  end
+  {
+    # There is no fauxhai info for windows 8, so we use windows 2012R2 and change the product type from server to workstation
+    'Windows 8.1' => { fauxhai_version: '2012R2', product_type: 1 },
+    'Windows Server 2012R2' => { fauxhai_version: '2012R2' }
+  }.each do |windows_version, test_conf|
+    context "on #{windows_version}" do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'windows', version: test_conf[:fauxhai_version]) do |node|
+          node.automatic['kernel']['os_info']['product_type'] = test_conf[:product_type] if test_conf[:product_type]
+          node.set['powershell']['powershell5']['url'] = 'https://powershelltest.com'
+          node.set['powershell']['powershell5']['checksum'] = '12345'
+        end.converge(described_recipe)
+      end
 
-  before do
-    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('powershell::powershell2').and_return(true)
-  end
+      it 'includes powershell 2 recipe' do
+        allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: false, value_exists?: false, key_exists?: false)
+        expect(chef_run).to include_recipe('powershell::powershell2')
+      end
 
-  context 'when windows_version is windows_server_2012_r2' do
-    before do
-      @windows_version = double(windows_server_2012_r2?: true, windows_8_1?: false)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(false)
-    end
+      context 'when powershell is installed' do
+        before do
+          allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: true, value_exists?: true)
+        end
 
-    it 'installs windows package windows managemet framework core 5.0 if powershell 5 not installed' do
-      expect(chef_run).to install_windows_package('Windows Management Framework Core 5.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
-    end
-  end
+        it 'does not install WMF 5' do
+          expect(chef_run).to_not install_windows_package('Windows Management Framework Core 5.0')
+        end
+      end
 
-  context 'when windows_version is windows_8_1' do
-    before do
-      @windows_version = double(windows_server_2012_r2?: false, windows_8_1?: true)
-      allow(Chef::ReservedNames::Win32::Version).to receive(:new).and_return(@windows_version)
-      registry = double
-      allow(Chef::Win32::Registry).to receive(:new).and_return(registry)
-      allow(registry).to receive(:data_exists?).and_return(false)
-    end
+      context 'when powershell does not exist' do
+        before do
+          allow(Chef::Win32::Registry).to receive(:new).and_return double('registry', data_exists?: false, value_exists?: false, key_exists?: false)
+        end
 
-    it 'installs windows package windows managemet framework core 5.0 if powershell not installed' do
-      expect(chef_run).to install_windows_package('Windows Management Framework Core 5.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
+        it 'installs windows package windows management framework core 5.0' do
+          expect(chef_run).to install_windows_package('Windows Management Framework Core 5.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
+        end
+      end
     end
   end
 end

--- a/spec/recipes/winrm_spec.rb
+++ b/spec/recipes/winrm_spec.rb
@@ -1,9 +1,13 @@
 require 'spec_helper'
-require 'chef/win32/version'
 
 describe 'powershell::winrm' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(platform: 'windows', version: '2012').converge(described_recipe)
+  end
+
+  before do
+    winrm_cmd = double('winrm_cmd', run_command: nil, stdout: 'Transport = HTTPS')
+    allow(Mixlib::ShellOut).to receive(:new).with('powershell.exe winrm enumerate winrm/config/listener').and_return winrm_cmd
   end
 
   it 'installs windows package windows managemet framework core 5.0' do


### PR DESCRIPTION
# Goal of this Pull Request
The main goal of this pull requests is to use [ms_dotnet] cookbook, instead of [ms_dotnet2] + [ms_dotnet4] + [ms_dotnet45] - some powershell recipes were even implementing there own way to enable .NET.

[ms_dotnet] is a 'all-in-one' cookbook allowing you to configure almost all .NET versions; it has been written following the same model as this [powershell] cookbook and is actively maintained by @criteo. 
Here are the reasons why I think `powershell` should use `ms_dotnet`:

1. having a single dependency to setup .NET is better than multiple ones.
2. `ms_dotnet` is more up-to-date than others cookbooks, it'll even soon [handle .NET 4.6](https://github.com/criteo-cookbooks/ms_dotnet/pull/9)
3. `ms_dotnet` is rspec testable on linux because it uses windows' ohais instead of Win32 API

# Content of this Pull Request
### Migration from ms_dotnetX to ms_dotnet
The first commit of this PR changed all references to ms_dotnet2, ms_dotnet4 and ms_dotnet5 into ms_dotnet reference.
Because a single recipe `ms_dotnet::ms_dotnet4` takes care of .NET 4 and .4.5, if attributes are not set properly `powershell4` recipe which require .NET 4.5 will throw an exception. 
I also removed some lines of code reimplementing .NET feature activation.

### Test fixes
Because migrating from one dependency cookbooks to another can be tricky, migrating from 3 to one require to be careful. One the most important thing I tried to keep in mind is to not break anything.
But ... it's hard when the tests are not passing to know if you are not breaking things; that's why I also focused on repairing the specs.

#### powershell recipes specs
I updated powershell recipes specs to ensure that they are properly testing the new code, and that all tests are useful - e.g. windows 7 Core does not exist, no need to test this case.
I tried to factorize at much as possible the tests, in order to avoid code/mistake duplication.

#### winrm and dsc recipes specs
I didn't spend too much time on theese specs, because I don't really understand why powershell cookbook include that kind of recipe; but I updated the specs to comply with other changes.

#### powershell module provider specs
These tests were failing for many reasons, one the worst one is that they were actually modifying the file system, I tried to remove all those file system operations by mocking them.
I also removed the use of environment variable.

### Rubocop and foodcritic fix
I finally fixed few rubocop and foodcritic violations, ignoring FC009 and refactoring winrm recipe's if statements.


Fixes #54 #56, and superseeds #55 #58 

cc: @aboten
[ms_dotnet]:http://supermarket.chef.io/cookbooks/ms_dotnet
[ms_dotnet2]:http://supermarket.chef.io/cookbooks/ms_dotnet2
[ms_dotnet4]:http://supermarket.chef.io/cookbooks/ms_dotnet4
[ms_dotnet45]:http://supermarket.chef.io/cookbooks/ms_dotnet45
[powershell]:http://supermarket.chef.io/cookbooks/powershell