### PR TITLE
Revert to WMF 5 Production Preview

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,58 @@
+---
+driver: 
+  name: azurerm
+  subscription_id: <%= ENV['AZURE_SUBSCRIPTION_ID'] %>
+  location: 'Central US'
+  machine_size: 'Basic_A2'
+
+provisioner:
+  name: chef_zero_scheduled_task
+  require_chef_omnibus: 12
+
+platforms:
+  - name: windows-2008r2-chef11.18.6
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:latest
+      winrm_powershell_script: |-
+        winrm quickconfig -q
+        winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
+        winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+        winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+        winrm set winrm/config/service/auth '@{Basic="true"}'
+        netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" profile=public protocol=tcp localport=5985 remoteip=localsubnet new remoteip=any
+    provisioner:
+      require_chef_omnibus: 11.18.6
+  - name: windows-2012-chef11.18.6
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:2012-Datacenter:latest
+    provisioner:
+      require_chef_omnibus: 11.18.6
+  - name: windows-2012r2-chef11.18.6
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:latest
+    provisioner:
+      require_chef_omnibus: 11.18.6
+  - name: windows-2016-tp-chef11.18.6
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:Windows-Server-Technical-Preview:latest
+    provisioner:
+      require_chef_omnibus: 11.18.6
+  - name: windows-2008r2-chef12
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:2008-R2-SP1:latest
+      winrm_powershell_script: |-
+        winrm quickconfig -q
+        winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="512"}'
+        winrm set winrm/config '@{MaxTimeoutms="1800000"}'
+        winrm set winrm/config/service '@{AllowUnencrypted="true"}'
+        winrm set winrm/config/service/auth '@{Basic="true"}'
+        netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" profile=public protocol=tcp localport=5985 remoteip=localsubnet new remoteip=any
+  - name: windows-2012-chef12
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:2012-Datacenter:latest
+  - name: windows-2012r2-chef12
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:latest
+  - name: windows-2016-tp-chef12
+    driver:
+      image_urn: MicrosoftWindowsServer:WindowsServer:Windows-Server-Technical-Preview:latest

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,5 +37,8 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[powershell::default]
       - recipe[minimal::default]
+  - name: powershell5
+    run_list:
+      - recipe[powershell::powershell5]
+    attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ powershell Cookbook CHANGELOG
 =============================
 This file is used to list changes made in each version of the powershell cookbook.
 
+v3.2.3 (2015-12-24)
+-------------------
+- [**smurawski**](https://github.com/smurawski)
+  [PR #71](https://github.com/chef-cookbooks/powershell/pull/71) - WMF 5 RTM was pulled - reverting to the production preview
+
 v3.2.2 (2015-12-18)
 -------------------
 - [**smurawski**](https://github.com/smurawski)

--- a/README.md
+++ b/README.md
@@ -32,38 +32,38 @@ Not every version of Windows supports every version of Powershell. The following
   <tr>
     <td>Windows Server 2003 / 2003 R2</td>
     <td>Supported</td>
-    <td></td>
-    <td></td>
-    <td></td>
+    <td>Not Available</td>
+    <td>Not Available</td>
+    <td>Not Available</td>
   </tr>
   <tr>
     <td>Windows Server 2008 / Vista</td>
     <td>Supported</td>
     <td>Supported</td>
-    <td></td>
-    <td></td>
+    <td>Not Available</td>
+    <td>Not Available</td>
   </tr>
   <tr>
     <td>Windows Server 2008 R2</td>
-    <td>Supported</td>
     <td>Included</td>
+    <td>Supported</td>
     <td>Supported</td>
     <td>Supported</td>
   </tr>
   <tr>
     <td>Windows Server 2012 / Windows 8</td>
-    <td>Supported</td>
+    <td>Included</td>
     <td>Included</td>
     <td>Supported</td>
     <td>Supported</td>
   </tr>
   <tr>
     <td>Windows Server 2012R2 / Windows 8.1</td>
-    <td></td>
-    <td></td>
+    <td>Included</td>
+    <td>Not Available</td>
     <td>Included</td>
     <td>Supported</td>
-  </tr> 
+  </tr>
 </table>
 
 ### Cookbooks
@@ -262,6 +262,9 @@ Include the `powershell4` recipe in a run list, to install PowerShell 4.0 is ins
 ### powershell5
 
 Note: Windows Management Framework 5 is in production preview.
+
+#### Windows Management Framework 5 RTM had been released, but that has been pulled.  The attributes in the cookbook have been reverted to the Production Preview.  When a new release of RTM for WMF 5 ships, we'll release an updated version.
+http://blogs.msdn.com/b/powershell/archive/2015/12/23/windows-management-framework-wmf-5-0-currently-removed-from-download-center.aspx
 
 Include the `powershell5` recipe in a run list, to install PowerShell 5.0 is installed on applicable platforms. If a platform is not supported or if it already includes PowerShell 5.0, an exception will be raised.
 

--- a/attributes/powershell5.rb
+++ b/attributes/powershell5.rb
@@ -19,32 +19,32 @@
 #
 
 if node['platform_family'] == 'windows'
-  default['powershell']['powershell5']['version'] = '5.0.10586.51'
+  default['powershell']['powershell5']['version'] = '5.0.10514.6'
 
   case node['platform_version'].split('.')[0..1].join('.')
   when '6.1'
     case node['kernel']['machine']
     when 'i386'
-      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win7-KB3094176-x86.msu'
-      default['powershell']['powershell5']['checksum'] = 'dfac22163aa6c51eaf0f0ae59a3f9632558aa08229350d0f272d742bd02f7109'
+      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win7AndW2K8R2-KB3066439-x86.msu'
+      default['powershell']['powershell5']['checksum'] = '8f019d7444b0995fe78bfc41115535c1f08ed9b08cd80f188d148bcd6c29d236'
     when 'x86_64'
-      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/W2K8R2-KB3094176-x64.msu'
-      default['powershell']['powershell5']['checksum'] = '22d4a4ff739a3734e1efa410bd9f745c668c31efeeffa170f7968d42022c641f'
+      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win7AndW2K8R2-KB3066439-x64.msu'
+      default['powershell']['powershell5']['checksum'] = '1c068cb6e342c2bc789bb009bc50d1bddc37e313106f696521c0b27b7cec3364'
     end
   when '6.2'
     case node['kernel']['machine']
     when 'x86_64'
-      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/W2K12-KB3094175-x64.msu'
-      default['powershell']['powershell5']['checksum'] = 'cfda8048978708fe4f31adb6c045e848db4af5decf88f64e38aa511db92e1d49'
+      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/W2K12-KB3066438-x64.msu'
+      default['powershell']['powershell5']['checksum'] = '281d85ec2317240f260f6a42c2c5c9dfbddfdb3bc361950f1ec29a7c06b8c857'
     end
   when '6.3'
     case node['kernel']['machine']
     when 'i386'
-      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1-KB3094174-x86.msu'
-      default['powershell']['powershell5']['checksum'] = '8e3a1414e57211623c2a6097dbdf982855f2e53fee65859dfa36891bf0be8e87'
+      default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win8.1AndW2K12R2-KB3066437-x86.msu'
+      default['powershell']['powershell5']['checksum'] = '0810a0eebf2239adde959561be8550f923ffb00e8b7d3a843143261937a0a5ab'
     when 'x86_64'
-      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/W2K12R2-KB3094174-x64.msu'
-      default['powershell']['powershell5']['checksum'] = 'cfda8048978708fe4f31adb6c045e848db4af5decf88f64e38aa511db92e1d49'
+      default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win8.1AndW2K12R2-KB3066437-x64.msu'
+      default['powershell']['powershell5']['checksum'] = '9c57302ff0515a6b7eb53ab07bed0f5d420bd7204296d9f3fd17452fca1d5b3d'
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs/Configures PowerShell on the Windows platform'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.2.2'
+version '3.2.3'
 
 recipe 'powershell::default', 'Makes sure RubyZip is installed (for powershell_module)'
 recipe 'powershell::powershell2', 'Installs PowerShell 2.0'

--- a/test/cookbooks/minimal/metadata.rb
+++ b/test/cookbooks/minimal/metadata.rb
@@ -1,2 +1,4 @@
 name 'minimal'
 version '0.0.1'
+
+depends 'powershell'

--- a/test/cookbooks/minimal/recipes/default.rb
+++ b/test/cookbooks/minimal/recipes/default.rb
@@ -1,4 +1,6 @@
 #
+include_recipe 'powershell::default'
+
 powershell_module 'posh-git' do
   package_name 'posh-git'
   source 'https://github.com/dahlbyk/posh-git/zipball/master'


### PR DESCRIPTION
Microsoft pulled WMF 5 RTM from the Download Center due to an issue with the installation.

I've reverted to the production preview for the powershell5 recipe.