### PR TITLE
Add ps5 timeout

### DIFF
--- a/attributes/powershell5.rb
+++ b/attributes/powershell5.rb
@@ -31,12 +31,14 @@ if node['platform_family'] == 'windows'
       default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win7AndW2K8R2-KB3066439-x64.msu'
       default['powershell']['powershell5']['checksum'] = '1c068cb6e342c2bc789bb009bc50d1bddc37e313106f696521c0b27b7cec3364'
     end
+    default['powershell']['powershell5']['timeout'] = 2700
   when '6.2'
     case node['kernel']['machine']
     when 'x86_64'
       default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/W2K12-KB3066438-x64.msu'
       default['powershell']['powershell5']['checksum'] = '281d85ec2317240f260f6a42c2c5c9dfbddfdb3bc361950f1ec29a7c06b8c857'
     end
+    default['powershell']['powershell5']['timeout'] = 2700
   when '6.3'
     case node['kernel']['machine']
     when 'i386'
@@ -46,5 +48,6 @@ if node['platform_family'] == 'windows'
       default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win8.1AndW2K12R2-KB3066437-x64.msu'
       default['powershell']['powershell5']['checksum'] = '9c57302ff0515a6b7eb53ab07bed0f5d420bd7204296d9f3fd17452fca1d5b3d'
     end
+    default['powershell']['powershell5']['timeout'] = 600
   end
 end

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -33,6 +33,7 @@ when 'windows'
       checksum node['powershell']['powershell5']['checksum']
       installer_type :custom
       options '/quiet /norestart'
+      timeout node['powershell']['powershell5']['timeout']
       action :install
       success_codes [0, 42, 127, 3010]
       # Note that the :immediately is to immediately notify the other resource,

--- a/spec/recipes/powershell5_spec.rb
+++ b/spec/recipes/powershell5_spec.rb
@@ -4,7 +4,7 @@ describe 'powershell::powershell5' do
   {
     # There is no fauxhai info for windows 8, so we use windows 2012R2 and change the product type from server to workstation
     'Windows 8.1' => { fauxhai_version: '2012R2', product_type: 1, timeout: 600 },
-    'Windows Server 2008R2' => { fauxhai_version: '2008R2', timeout: 2700},
+    'Windows Server 2008R2' => { fauxhai_version: '2008R2', timeout: 2700 },
     'Windows Server 2012' => { fauxhai_version: '2012', timeout: 2700 },
     'Windows Server 2012R2' => { fauxhai_version: '2012R2', timeout: 600 }
   }.each do |windows_version, test_conf|

--- a/spec/recipes/powershell5_spec.rb
+++ b/spec/recipes/powershell5_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 describe 'powershell::powershell5' do
   {
     # There is no fauxhai info for windows 8, so we use windows 2012R2 and change the product type from server to workstation
-    'Windows 8.1' => { fauxhai_version: '2012R2', product_type: 1 },
-    'Windows Server 2012R2' => { fauxhai_version: '2012R2' }
+    'Windows 8.1' => { fauxhai_version: '2012R2', product_type: 1, timeout: 600 },
+    'Windows Server 2008R2' => { fauxhai_version: '2008R2', timeout: 2700},
+    'Windows Server 2012' => { fauxhai_version: '2012', timeout: 2700 },
+    'Windows Server 2012R2' => { fauxhai_version: '2012R2', timeout: 600 }
   }.each do |windows_version, test_conf|
     context "on #{windows_version}" do
       let(:chef_run) do
@@ -36,7 +38,7 @@ describe 'powershell::powershell5' do
         end
 
         it 'installs windows package windows management framework core 5.0' do
-          expect(chef_run).to install_windows_package('Windows Management Framework Core 5.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart')
+          expect(chef_run).to install_windows_package('Windows Management Framework Core 5.0').with(source: 'https://powershelltest.com', checksum: '12345', installer_type: :custom, options: '/quiet /norestart', timeout: test_conf[:timeout])
         end
       end
     end


### PR DESCRIPTION
This PR adds a timeout attribute to the powershell5 recipe allowing the successful installation on 2012, and 2008R2 instances. 