### PR TITLE
MSU exit code 2359302

### DIFF
--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -35,7 +35,7 @@ when 'windows'
       options '/quiet /norestart'
       timeout node['powershell']['powershell5']['timeout']
       action :install
-      success_codes [0, 42, 127, 3010]
+      success_codes [0, 42, 127, 3010, 2359302]
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'


### PR DESCRIPTION
MSU should not fail on exit code 2359302 (WU_S_ALREADY_INSTALLED) because it only means it has been already installed. Without this change when I am unable to converge the kitchen recipe twice in a row without an error. This would happen if you apply the recipe twice without a reboot.