### PR TITLE
Update WMF 5 binaries to the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,6 @@ Include the `powershell4` recipe in a run list, to install PowerShell 4.0 is ins
 
 ### powershell5
 
-Note: Windows Management Framework 5 is in production preview.
-
-#### Windows Management Framework 5 RTM had been released, but that has been pulled.  The attributes in the cookbook have been reverted to the Production Preview.  When a new release of RTM for WMF 5 ships, we'll release an updated version.
-http://blogs.msdn.com/b/powershell/archive/2015/12/23/windows-management-framework-wmf-5-0-currently-removed-from-download-center.aspx
-
 Include the `powershell5` recipe in a run list, to install PowerShell 5.0 is installed on applicable platforms. If a platform is not supported or if it already includes PowerShell 5.0, an exception will be raised.
 
 References
@@ -275,7 +270,7 @@ References
 * Installing [Windows Management Framework 2.0](http://support.microsoft.com/kb/968929)
 * Installing [Windows Management Framework 3.0](http://www.microsoft.com/en-us/download/details.aspx?id=34595)
 * Installing [Windows Management Framework 4.0](http://www.microsoft.com/en-us/download/details.aspx?id=40855)
-* Installing [Windows Management Framework 5.0](https://www.microsoft.com/en-us/download/details.aspx?id=48729)
+* Installing [Windows Management Framework 5.0](https://www.microsoft.com/en-us/download/details.aspx?id=50395)
 
 License & Authors
 -----------------

--- a/attributes/powershell5.rb
+++ b/attributes/powershell5.rb
@@ -19,34 +19,34 @@
 #
 
 if node['platform_family'] == 'windows'
-  default['powershell']['powershell5']['version'] = '5.0.10514.6'
+  default['powershell']['powershell5']['version'] = '5.0.10586.117'
 
   case node['platform_version'].split('.')[0..1].join('.')
   when '6.1'
     case node['kernel']['machine']
     when 'i386'
-      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win7AndW2K8R2-KB3066439-x86.msu'
-      default['powershell']['powershell5']['checksum'] = '8f019d7444b0995fe78bfc41115535c1f08ed9b08cd80f188d148bcd6c29d236'
+      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win7-KB3134760-x86.msu'
+      default['powershell']['powershell5']['checksum'] = '0486901b4fd9c41a70644e3a427fe06dd23765f1ad8b45c14be3321203695464'
     when 'x86_64'
-      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win7AndW2K8R2-KB3066439-x64.msu'
-      default['powershell']['powershell5']['checksum'] = '1c068cb6e342c2bc789bb009bc50d1bddc37e313106f696521c0b27b7cec3364'
+      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win7AndW2K8R2-KB3134760-x64.msu'
+      default['powershell']['powershell5']['checksum'] = '077e864cc83739ac53750c97a506e1211f637c3cd6da320c53bb01ed1ef7a98b'
     end
     default['powershell']['powershell5']['timeout'] = 2700
   when '6.2'
     case node['kernel']['machine']
     when 'x86_64'
-      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/W2K12-KB3066438-x64.msu'
-      default['powershell']['powershell5']['checksum'] = '281d85ec2317240f260f6a42c2c5c9dfbddfdb3bc361950f1ec29a7c06b8c857'
+      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/W2K12-KB3134759-x64.msu'
+      default['powershell']['powershell5']['checksum'] = '6e59cec4bd30c505f426a319673a13c4a9aa8d8ff69fd0582bfa89f522f5ff00'
     end
     default['powershell']['powershell5']['timeout'] = 2700
   when '6.3'
     case node['kernel']['machine']
     when 'i386'
-      default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win8.1AndW2K12R2-KB3066437-x86.msu'
-      default['powershell']['powershell5']['checksum'] = '0810a0eebf2239adde959561be8550f923ffb00e8b7d3a843143261937a0a5ab'
+      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1-KB3134758-x86.msu'
+      default['powershell']['powershell5']['checksum'] = 'f9ee4bf2d826827bc56cd58fabd0529cb4b49082b2740f212851cc0cc4acba06'
     when 'x86_64'
-      default['powershell']['powershell5']['url'] = 'http://download.microsoft.com/download/3/F/D/3FD04B49-26F9-4D9A-8C34-4533B9D5B020/Win8.1AndW2K12R2-KB3066437-x64.msu'
-      default['powershell']['powershell5']['checksum'] = '9c57302ff0515a6b7eb53ab07bed0f5d420bd7204296d9f3fd17452fca1d5b3d'
+      default['powershell']['powershell5']['url'] = 'https://download.microsoft.com/download/2/C/6/2C6E1B4A-EBE5-48A6-B225-2D2058A9CEFB/Win8.1AndW2K12R2-KB3134758-x64.msu'
+      default['powershell']['powershell5']['checksum'] = 'bb6af4547545b5d10d8ef239f47d59de76daff06f05d0ed08c73eff30b213bf2'
     end
     default['powershell']['powershell5']['timeout'] = 600
   end


### PR DESCRIPTION
This updates the WMF 5 binaries and version to the latest release as the cookbook was referencing RTM version. Updated the readme to remove disclaimer about WMF 5.
