### PR TITLE
added success code 2359302

### DIFF
--- a/recipes/powershell2.rb
+++ b/recipes/powershell2.rb
@@ -51,7 +51,7 @@ when 'windows'
       checksum node['powershell']['powershell2']['checksum']
       installer_type :custom
       options '/quiet /norestart'
-      success_codes [0, 42, 127, 3010]
+      success_codes [0, 42, 127, 3010, 2_359_302]
       action :install
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.

--- a/recipes/powershell3.rb
+++ b/recipes/powershell3.rb
@@ -55,7 +55,7 @@ when 'windows'
       checksum node['powershell']['powershell3']['checksum']
       installer_type :custom
       options '/quiet /norestart'
-      success_codes [0, 42, 127, 3010]
+      success_codes [0, 42, 127, 3010, 2_359_302]
       action :install
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -42,7 +42,7 @@ if node['platform'] == 'windows'
       installer_type :custom
       options '/quiet /norestart'
       action :install
-      success_codes [0, 42, 127, 3010]
+      success_codes [0, 42, 127, 3010, 2_359_302]
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'


### PR DESCRIPTION
Added success to code 2359302 to powershell2, powershell3, and powershell4 recipes. Without this, a terminating error is thrown upon the second run if the node is not rebooted after installation.

Essentially, this is creating conformity with the change made in PR #83.