### PR TITLE
remove deprecation warning

### DIFF
--- a/libraries/powershell_module_resource.rb
+++ b/libraries/powershell_module_resource.rb
@@ -22,7 +22,7 @@ require_relative 'powershell_module_provider'
 class PowershellModule < Chef::Resource::Package
   state_attrs :enabled
 
-  provides :powershell_module, on_platforms: ['windows']
+  provides :powershell_module, platform: ['windows']
 
   def initialize(name, run_context = nil)
     super


### PR DESCRIPTION
### Description

This PR removes deprecation warning introduced by this change in chef repo
https://github.com/chef/chef/commit/97aaf5bbcdfd0810722b123bdc67e883a7ca8077

### Issues Resolved

* fix deprecation warning

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing. **there is no new functionality**
- [ ] New functionality has been documented in the README if applicable  **there is no new functionality**
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD