### PR TITLE
removed windows_reboot and windows::reboot_handler.

### DIFF
--- a/recipes/powershell3.rb
+++ b/recipes/powershell3.rb
@@ -44,7 +44,7 @@ if platform_family?('windows')
       action :install
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
-      notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
+      notifies :reboot_now, 'reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
       not_if { ::Powershell::VersionHelper.powershell_version?('3.0') }
     end
   else

--- a/recipes/powershell3.rb
+++ b/recipes/powershell3.rb
@@ -44,7 +44,7 @@ if platform_family?('windows')
       action :install
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
-      notifies :reboot_now, 'reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
+      notifies :reboot_now, 'reboot[powershell]', :immediately if node['powershell']['installation_reboot_mode'] != 'no_reboot'
       not_if { ::Powershell::VersionHelper.powershell_version?('3.0') }
     end
   else

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -45,7 +45,7 @@ if platform_family?('windows')
       success_codes [0, 42, 127, 3010, 2_359_302]
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
-      notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
+      notifies :reboot_now, 'reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
       not_if { ::Powershell::VersionHelper.powershell_version?('4.0') }
     end
   else

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -45,7 +45,7 @@ if platform_family?('windows')
       success_codes [0, 42, 127, 3010, 2_359_302]
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
-      notifies :reboot_now, 'reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
+      notifies :reboot_now, 'reboot[powershell]', :immediately if node['powershell']['installation_reboot_mode'] != 'no_reboot'
       not_if { ::Powershell::VersionHelper.powershell_version?('4.0') }
     end
   else

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -38,7 +38,7 @@ if platform_family?('windows')
       success_codes [0, 42, 127, 3010, 2_359_302]
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
-      notifies :request, 'windows_reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
+      notifies :reboot_now, 'reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
       not_if { ::Powershell::VersionHelper.powershell_version?(node['powershell']['powershell5']['version']) }
     end
 

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -38,7 +38,7 @@ if platform_family?('windows')
       success_codes [0, 42, 127, 3010, 2_359_302]
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
-      notifies :reboot_now, 'reboot[powershell]', :immediately if reboot_pending? && node['powershell']['installation_reboot_mode'] != 'no_reboot'
+      notifies :reboot_now, 'reboot[powershell]', :immediately if node['powershell']['installation_reboot_mode'] != 'no_reboot'
       not_if { ::Powershell::VersionHelper.powershell_version?(node['powershell']['powershell5']['version']) }
     end
 

--- a/recipes/windows_reboot.rb
+++ b/recipes/windows_reboot.rb
@@ -2,11 +2,7 @@
 node.default['windows']['allow_pending_reboots'] = true
 node.default['windows']['allow_reboot_on_failure'] = true
 
-include_recipe 'windows::reboot_handler'
-
-windows_reboot 'powershell' do
-  reason 'Reboot after successful/unsuccessful powershell installation'
-  timeout node['powershell']['reboot_timeout_seconds']
+reboot 'powershell' do
   action :nothing
   notifies :run, 'ruby_block[end_chef_run]', :immediately if node['powershell']['installation_reboot_mode'] == 'immediate_reboot'
 end

--- a/recipes/windows_reboot.rb
+++ b/recipes/windows_reboot.rb
@@ -4,14 +4,4 @@ node.default['windows']['allow_reboot_on_failure'] = true
 
 reboot 'powershell' do
   action :nothing
-  notifies :run, 'ruby_block[end_chef_run]', :immediately if node['powershell']['installation_reboot_mode'] == 'immediate_reboot'
-end
-
-# The reboot handler only does something at the end of the chef run. If it
-# needs to happen straight away to be useful, throw an exception...
-ruby_block 'end_chef_run' do
-  block do
-    raise 'Requested sudden end to the run... I hope this was justified.'
-  end
-  action :nothing
 end


### PR DESCRIPTION
### Description

Drops the windows_reboot resource and the windows::reboot_handler recipe.  The no longer exist in the windows cookbook.

### Issues Resolved

None that I know of. 

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


That resource and recipe has been dropped from the windows cookbook. replace windows_reboot with the reboot resource.