### PR TITLE
Add `returns` property to windows_package resource

### DIFF
--- a/recipes/powershell3.rb
+++ b/recipes/powershell3.rb
@@ -40,7 +40,7 @@ if platform_family?('windows')
       checksum node['powershell']['powershell3']['checksum']
       installer_type :custom
       options '/quiet /norestart'
-      success_codes [0, 42, 127, 3010, 2_359_302]
+      returns [0, 42, 127, 3010, 2_359_302]
       action :install
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.

--- a/recipes/powershell4.rb
+++ b/recipes/powershell4.rb
@@ -42,7 +42,7 @@ if platform_family?('windows')
       installer_type :custom
       options '/quiet /norestart'
       action :install
-      success_codes [0, 42, 127, 3010, 2_359_302]
+      returns [0, 42, 127, 3010, 2_359_302]
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :reboot_now, 'reboot[powershell]', :immediately if node['powershell']['installation_reboot_mode'] != 'no_reboot'

--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -35,7 +35,7 @@ if platform_family?('windows')
       options '/quiet /norestart'
       timeout node['powershell']['powershell5']['timeout']
       action :install
-      success_codes [0, 42, 127, 3010, 2_359_302]
+      returns [0, 42, 127, 3010, 2_359_302]
       # Note that the :immediately is to immediately notify the other resource,
       # not to immediately reboot. The windows_reboot 'notifies' does that.
       notifies :reboot_now, 'reboot[powershell]', :immediately if node['powershell']['installation_reboot_mode'] != 'no_reboot'


### PR DESCRIPTION
### Description
The windows_package resource has been removed in windows
cookbook >= 3.0. Change exit code property from `success_codes` to
`returns` to meet built into chef-client 12.6+ `windows_package`.

### Issues Resolved

https://github.com/chef-cookbooks/powershell/issues/104

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
