### PR TITLE
Override Appveyor line ending settings, use CRLF on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ skip_tags: true
 #faster cloning
 clone_depth: 1
 
+# Allow Windows builds to use CRLF as expected by linting tools, etc.
+init:
+  - git config --global core.autocrlf true
+
 # Install the latest nightly of ChefDK
 install:
   - ps: iex (irm https://omnitruck.chef.io/install.ps1); Install-Project -Project chefdk


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Allows Appveyor builds to honor the correct line ending for Windows, when built on Windows

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
