### PR TITLE
Added guard to not unzip WMF if already installed

### DIFF
--- a/recipes/powershell5.rb
+++ b/recipes/powershell5.rb
@@ -36,6 +36,7 @@ if platform_family?('windows')
       source node['powershell']['powershell5']['url']
       checksum node['powershell']['powershell5']['checksum']
       action :unzip
+      not_if { ::Powershell::VersionHelper.powershell_version?(node['powershell']['powershell5']['version']) }
     end
 
     windows_package 'Windows Management Framework Core 5.1' do # ~FC009

--- a/spec/recipes/powershell5_spec.rb
+++ b/spec/recipes/powershell5_spec.rb
@@ -41,6 +41,9 @@ describe 'powershell::powershell5' do
           allow(::Powershell::VersionHelper).to receive(:powershell_version?).and_return true
         end
 
+        it 'does not unzip WMF 5.1' do
+          expect(chef_run).to_not unzip_windows_zipfile("#{Chef::Config['file_cache_path']}\\wmf51")
+        end
         it 'does not install WMF 5.1' do
           expect(chef_run).to_not install_windows_package('Windows Management Framework Core 5.1')
         end


### PR DESCRIPTION
Signed-off-by: Robb Schiefer <rschiefer@live.com>

### Description

Avoids unnecessary resource execution, specifically the WMF unzip when its already installed.

### Issues Resolved

NA

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
